### PR TITLE
[TRAF-15] Spread other props in section tag

### DIFF
--- a/src/components/PageSection/PageSection-component.jsx
+++ b/src/components/PageSection/PageSection-component.jsx
@@ -2,6 +2,8 @@ import React from 'react';
 
 import './PageSection-styles.scss';
 
-const PageSection = ({ children }) => <section>{children}</section>;
+const PageSection = ({ children, ...otherProps }) => (
+  <section {...otherProps}>{children}</section>
+);
 
 export default PageSection;


### PR DESCRIPTION
spreading `otherProps` lets you add classname and other props when you reuse the component  